### PR TITLE
Added Redis caching for event management endpoints to improve performance.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,11 +5,15 @@ on: [ push, pull_request ]
 jobs:
   build:
     runs-on: ubuntu-latest
+    services:
+      redis:
+        image: redis:latest
+        ports:
+          - 6379:6379
 
     defaults:
       run:
         working-directory: ./backend
-
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 17
@@ -18,13 +22,6 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
           cache: maven
-
-#      - name: Change to backend directory
-#        run: cd backend
-#      - name: Build with Maven
-#        run: cd backend && mvn --batch-mode verify
-#      - name: Run tests
-#        run: cd backend && mvn test
       - name: Build and run Unit/Integration Tests with Maven
         run: mvn -ntp -B verify
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,14 @@
 name: Java CI
 
-on: [push, pull_request]
+on: [ push, pull_request ]
 
 jobs:
   build:
     runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: ./backend
 
     steps:
       - uses: actions/checkout@v4
@@ -14,11 +18,14 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
           cache: maven
-      - name: Change to backend directory
-        run: cd backend
-      - name: Build with Maven
-        run: cd backend && mvn --batch-mode verify
-      - name: Run tests
-        run: cd backend && mvn test
+
+#      - name: Change to backend directory
+#        run: cd backend
+#      - name: Build with Maven
+#        run: cd backend && mvn --batch-mode verify
+#      - name: Run tests
+#        run: cd backend && mvn test
+      - name: Build and run Unit/Integration Tests with Maven
+        run: mvn -ntp -B verify
 
 

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -109,6 +109,10 @@
             <artifactId>hibernate-validator</artifactId>
             <version>8.0.1.Final</version>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-redis</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/backend/src/main/java/cu/theater/backend/BackendApplication.java
+++ b/backend/src/main/java/cu/theater/backend/BackendApplication.java
@@ -2,8 +2,10 @@ package cu.theater.backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 
 @SpringBootApplication
+@EnableCaching
 public class BackendApplication {
 
     public static void main(String[] args) {

--- a/backend/src/main/java/cu/theater/backend/controller/EventController.java
+++ b/backend/src/main/java/cu/theater/backend/controller/EventController.java
@@ -6,6 +6,10 @@ import cu.theater.backend.service.event.EventService;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheConfig;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.CachePut;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -19,6 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/events")
+@CacheConfig(cacheNames = {"eventResponse"})
 @RequiredArgsConstructor
 public class EventController {
     private final EventService eventService;
@@ -30,23 +35,27 @@ public class EventController {
     }
 
     @PutMapping("/{id}")
+    @CachePut(key = "#id")
     public EventResponseDto updateEvent(@PathVariable Long id,
-                                                @Valid @RequestBody EventRequestDto request) {
+                                        @Valid @RequestBody EventRequestDto request) {
         return eventService.update(id, request);
     }
 
     @GetMapping
+    @Cacheable(key = "'allEvents'")
     public List<EventResponseDto> getAllEvents() {
         return eventService.getAll();
     }
 
     @GetMapping("/{id}")
+    @Cacheable(key = "#id")
     public EventResponseDto getEventById(@PathVariable Long id) {
         return eventService.getById(id);
     }
 
     @DeleteMapping("/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
+    @CacheEvict(key = "#id", beforeInvocation = true)
     public void deleteEvent(@PathVariable Long id) {
         eventService.delete(id);
     }

--- a/backend/src/main/java/cu/theater/backend/dto/event/EventRequestDto.java
+++ b/backend/src/main/java/cu/theater/backend/dto/event/EventRequestDto.java
@@ -3,12 +3,13 @@ package cu.theater.backend.dto.event;
 import cu.theater.backend.model.Event;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import java.io.Serializable;
 import java.math.BigDecimal;
 import lombok.Data;
 import org.hibernate.validator.constraints.Length;
 
 @Data
-public class EventRequestDto {
+public class EventRequestDto implements Serializable {
     @NotBlank
     @Length(min = 4, max = 35)
     private String name;

--- a/backend/src/main/java/cu/theater/backend/dto/event/EventResponseDto.java
+++ b/backend/src/main/java/cu/theater/backend/dto/event/EventResponseDto.java
@@ -1,11 +1,12 @@
 package cu.theater.backend.dto.event;
 
 import cu.theater.backend.model.Event;
+import java.io.Serializable;
 import java.math.BigDecimal;
 import lombok.Data;
 
 @Data
-public class EventResponseDto {
+public class EventResponseDto implements Serializable {
     private Long id;
     private String name;
     private String description;

--- a/backend/src/main/java/cu/theater/backend/service/event/EventServiceImpl.java
+++ b/backend/src/main/java/cu/theater/backend/service/event/EventServiceImpl.java
@@ -24,6 +24,7 @@ public class EventServiceImpl implements EventService {
 
     @Override
     public EventResponseDto update(Long id, EventRequestDto requestDto) {
+        System.out.println("DB Called!");
         eventRepository.findById(id).orElseThrow(() ->
                 new EntityNotFoundException("Can't find event with id: " + id));
         Event event = eventMapper.toModel(requestDto);
@@ -33,6 +34,7 @@ public class EventServiceImpl implements EventService {
 
     @Override
     public List<EventResponseDto> getAll() {
+        System.out.println("DB Called!");
         return eventRepository.findAll().stream()
                 .map(eventMapper::toDto)
                 .toList();
@@ -40,6 +42,7 @@ public class EventServiceImpl implements EventService {
 
     @Override
     public EventResponseDto getById(Long id) {
+        System.out.println("DB Called!");
         return eventMapper.toDto(eventRepository.findById(id).orElseThrow(() ->
                 new EntityNotFoundException("Can't find event with id: " + id)));
     }

--- a/backend/src/main/java/cu/theater/backend/service/event/EventServiceImpl.java
+++ b/backend/src/main/java/cu/theater/backend/service/event/EventServiceImpl.java
@@ -24,7 +24,6 @@ public class EventServiceImpl implements EventService {
 
     @Override
     public EventResponseDto update(Long id, EventRequestDto requestDto) {
-        System.out.println("DB Called!");
         eventRepository.findById(id).orElseThrow(() ->
                 new EntityNotFoundException("Can't find event with id: " + id));
         Event event = eventMapper.toModel(requestDto);
@@ -34,7 +33,6 @@ public class EventServiceImpl implements EventService {
 
     @Override
     public List<EventResponseDto> getAll() {
-        System.out.println("DB Called!");
         return eventRepository.findAll().stream()
                 .map(eventMapper::toDto)
                 .toList();
@@ -42,7 +40,6 @@ public class EventServiceImpl implements EventService {
 
     @Override
     public EventResponseDto getById(Long id) {
-        System.out.println("DB Called!");
         return eventMapper.toDto(eventRepository.findById(id).orElseThrow(() ->
                 new EntityNotFoundException("Can't find event with id: " + id)));
     }

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -4,6 +4,12 @@ spring.datasource.username=root
 spring.datasource.password=root
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
+## Redis Settings
+spring.cache.type=redis
+spring.data.redis.host=localhost
+spring.data.redis.port=6379
+spring.cache.redis.time-to-live=600000
+
 ## JPA/Hibernate Configuration
 spring.jpa.hibernate.ddl-auto=validate
 spring.jpa.show-sql=true
@@ -14,3 +20,4 @@ jwt.secret=SecretKeyToGenJWTswqeqeqweqweqeqweqweqweqwe123123
 
 ## Server Settings
 server.servlet.context-path=/api
+


### PR DESCRIPTION
- Configured caching for the following methods:
  - `getAllEvents`: Caches the list of all events using the key 'allEvents'.
  - `getEventById`: Caches individual event details using the event ID as the key.
  - `updateEvent`: Updates the cache when an event is updated, using the event ID as the key.
  - `deleteEvent`: Evicts the cached event data when an event is deleted to ensure consistency.
- Applied `@Cacheable` to cache responses and `@CacheEvict` to clear cache entries on deletion.
- Updated `EventController` to integrate caching strategies with Redis.